### PR TITLE
Add support for pre-tags, add options for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ You can configure the behaviour of html-to-text with the following options:
 
  * `tables` allows to select certain tables by the `class` or `id` attribute from the HTML document. This is necessary because the majority of HTML E-Mails uses a table based layout. Prefix your table selectors with an `.` for the `class` and with a `#` for the `id` attribute. All other tables are ignored. You can assign `true` to this attribute to select all tables. Default: `[]`
  * `wordwrap` defines after how many chars a line break should follow in `p` elements. Default: `80`
+ * `linkHrefBaseUrl` allows you to specify the server host for href attributes, where the links start at the root (`/`). For example, `linkHrefBaseUrl = 'http://asdf.com'` and `<a href='/dir/subdir'>...</a>` the link in the text will be `http://asdf.com/dir/subdir`. Keep in mind that `linkHrefBaseUrl` shouldn't end with a `/`.
+ * `hideLinkHrefIfSameAsText` by default links are translated the following `<a href='link'>text</a>` => becomes => `text [link]`. If this option is set to true and `link` and `text` are the same, `[link]` will be hidden and only `text` visible.
 
 ## Command Line Interface
 

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -4,9 +4,14 @@ var _s = require('underscore.string');
 var helper = require('./helper');
 
 function formatText(elem, options) {
-	var text = _s.strip(elem.raw);
+	var text = (options.isInPre ? elem.raw : _s.strip(elem.raw));
 	text = helper.decodeHTMLEntities(text);
-	return helper.wordwrap(elem.needsSpace ? ' ' + text : text, options.wordwrap);
+
+	if (options.isInPre) {
+		return text;
+	} else {
+		return helper.wordwrap(elem.needsSpace ? ' ' + text : text, options.wordwrap);
+	}
 }
 
 function formatImage(elem, options) {
@@ -52,13 +57,18 @@ function formatAnchor(elem, fn, options) {
 		href = elem.attribs.href.replace(/^mailto\:/, '');
 	}
 	if (href) {
-		result += ' [' + href + ']';
+		if (options.linkHrefBaseUrl && href.indexOf('/') == 0) {
+			href = options.linkHrefBaseUrl + href;
+		}
+		if (!options.hideLinkHrefIfSameAsText || href != result) {
+			result += ' [' + href + ']';
+		}
 	}
 	return formatText({ raw: result || href, needsSpace: elem.needsSpace }, options);
 }
 
 function formatHorizontalLine(elem, fn, options) {
-	return _s.repeat('-', options.wordwrap) + '\n\n';
+	return '\n' + _s.repeat('-', options.wordwrap) + '\n\n';
 }
 
 function formatListItem(prefix, elem, fn, options) {

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -13,12 +13,15 @@ var SKIP_TYPES = [
 	'style',
 	'script'
 ];
+var previousTagPreIgnoreNextText = false;
 
 function htmlToText(html, options) {
 	options = options || {};
 	_.defaults(options, {
 		wordwrap: 80,
-		tables: []
+		tables: [],
+		hideLinkHrefIfSameAsText: false,
+		linkHrefBaseUrl: null,
 	});
 
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
@@ -113,12 +116,19 @@ function walk(dom, options) {
 							result += format.table(elem, walk, options);
 							break;
 						}
+					case 'pre':
+						var newOptions = _(options).clone();
+						newOptions.isInPre = true;
+						result += format.paragraph(elem, walk, newOptions);
+						previousTagPreIgnoreNextText = true;
 					default:
 						result += walk(elem.children || [], options);
 				}
 				break;
 			case 'text':
-				if (elem.raw !== '\r\n') {
+				if (previousTagPreIgnoreNextText) {
+					previousTagPreIgnoreNextText = false
+				} else if (elem.raw !== '\r\n') {
 					// Text needs a leading space if `result` currently
 					// doesn't end with whitespace
 					elem.needsSpace = whiteSpaceRegex.test(result);

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -73,8 +73,10 @@ function containsTable(attr, tables) {
 	return attr && (_.include(classes, attr.class) || _.include(ids, attr.id));
 }
 
-function walk(dom, options) {
-	var result = '';
+function walk(dom, options, result) {
+	if (arguments.length < 3) {
+		result = '';
+	}
 	var whiteSpaceRegex = /\S$/;
 	_.each(dom, function(elem) {
 		switch(elem.type) {
@@ -121,7 +123,7 @@ function walk(dom, options) {
 							break;
 						}
 					default:
-						result += walk(elem.children || [], options);
+						result = walk(elem.children || [], options, result);
 				}
 				break;
 			case 'text':
@@ -134,7 +136,7 @@ function walk(dom, options) {
 				break;
 			default:
 				if (!_.include(SKIP_TYPES, elem.type)) {
-					result += walk(elem.children || [], options);
+					result = walk(elem.children || [], options, result);
 				}
 		}
 	});

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -13,7 +13,6 @@ var SKIP_TYPES = [
 	'style',
 	'script'
 ];
-var previousTagPreIgnoreNextText = false;
 
 function htmlToText(html, options) {
 	options = options || {};
@@ -111,24 +110,22 @@ function walk(dom, options) {
 					case 'ol':
 						result += format.orderedList(elem, walk, options);
 						break;
+					case 'pre':
+						var newOptions = _(options).clone();
+						newOptions.isInPre = true;
+						result += format.paragraph(elem, walk, newOptions);
+						break;
 					case 'table':
 						if (containsTable(elem.attribs, options.tables)) {
 							result += format.table(elem, walk, options);
 							break;
 						}
-					case 'pre':
-						var newOptions = _(options).clone();
-						newOptions.isInPre = true;
-						result += format.paragraph(elem, walk, newOptions);
-						previousTagPreIgnoreNextText = true;
 					default:
 						result += walk(elem.children || [], options);
 				}
 				break;
 			case 'text':
-				if (previousTagPreIgnoreNextText) {
-					previousTagPreIgnoreNextText = false
-				} else if (elem.raw !== '\r\n') {
+				if (elem.raw !== '\r\n') {
 					// Text needs a leading space if `result` currently
 					// doesn't end with whitespace
 					elem.needsSpace = whiteSpaceRegex.test(result);


### PR DESCRIPTION
1. I've added support for pre - as that is already raw text it shouldn't be formatted anymore.
2. Additionally there are two options for a-tags (described in the README).
3. I've also had problems with the hr - for some reason in some cases a new line was missing, so I've added one manually. For me it's better there is a new line too much than one missing.