### PR TITLE
Add failing test case for links followed by punctuation

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -128,6 +128,7 @@
 						Somewhere<br />
 						E-Mail: <a href="mailto:test@example.com">Click here</a>
 					</p>
+					<p>We appreciate your business. And we hope you'll check out our <a href="http://example.com/">new products</a>!</p>
 				</td>
 			</tr>
 		</table>

--- a/test/test.txt
+++ b/test/test.txt
@@ -52,3 +52,5 @@ Some Company
 Some Street 42
 Somewhere
 E-Mail: Click here [test@example.com]
+
+We appreciate your business. And we hope you'll check out our new products [http://example.com/]!


### PR DESCRIPTION
I'm pretty sure that the HTML ``the <a href="http://example.com">test</a>!`` should render in plaintext as ``the test [http://example.com/]!`, not ``the test [http://example.com/] !``, which is how it does now. (Note the space before the exclamation point). So I wanted to add a test for this case, to document it as an issue and make it easy to track when it's fixed.