### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,7 @@
     "email": "legenhausen@werk85.de"
   },
   "homepage": "https://github.com/werk85/node-html-to-text",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/werk85/node-html-to-text/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/werk85/node-html-to-text.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/