### PR TITLE
bump iojs up to @2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "converter"
   ],
   "engines": {
-    "node": ">= 0.8.0 <=0.12 || <=1.4.0"
+    "node": ">= 0.8.0 <=0.12 || <3"
   },
   "bin": {
     "html-to-text": "./bin/cli.js"


### PR DESCRIPTION
iojs have already released 2.2.1 version, so node-html-to-text need to update engine field.

btw, do you really need this field? cause it’s not only complaining and not really care about engine versions, as far as library is not testing under all stated engines in the CI