### PR TITLE
Limit require() of node modules / Firefox SDK compatibility

### DIFF
--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -1,5 +1,6 @@
-var fs = require('fs');
-var util = require('util');
+try {
+	var fs = require('fs');
+} catch (e) {}
 
 var _ = require('underscore');
 var _s = require('underscore.string');


### PR DESCRIPTION
## Current situation
The [first two lines in `lib/html-to-text.js`](https://github.com/werk85/node-html-to-text/blob/92edddc8b3f4e2a39ee1bf09de5967cef9ac6c34/lib/html-to-text.js#L1-L2) currently are:

```js
var fs = require('fs');
var util = require('util');
```

Of these two, `util` is never used, and `fs` only if `fromFile()` is called.

## Problem
I'm trying to use html-to-text in a Firefox addon, using the Firefox SDK. In this environment, there are no `fs` and `util` modules, thus the `require()` calls fail.

## Solution
I managed to get it working in the addon by wrapping these two lines in a try/catch-block (and with another modification to the `htmlparser` dependency). Since `util` is never used, it can be removed entirely. As for `fs`, I wrapped it in a try/catch block – an alternative would be to require it only when used.