### PR TITLE
Updated engines to remove upper version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "converter"
   ],
   "engines": {
-    "node": ">= 0.8.0 <=0.12 || <3"
+    "node": ">= 0.8.0"
   },
   "bin": {
     "html-to-text": "./bin/cli.js"


### PR DESCRIPTION
What do you think @mlegenhausen? A [few](https://github.com/elastic/elasticsearch-js/commit/6e0d273d75201306a493de8471f9814625f5dc4c#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L101) others have done this.