### PR TITLE
Removed an extra comma & updated attr accessor for 'class' for IE fix

### DIFF
--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -20,7 +20,7 @@ function htmlToText(html, options) {
 		wordwrap: 80,
 		tables: [],
 		hideLinkHrefIfSameAsText: false,
-		linkHrefBaseUrl: null,
+		linkHrefBaseUrl: null
 	});
 
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
@@ -70,7 +70,7 @@ function containsTable(attr, tables) {
 	}
 	var classes = filterByPrefix(tables, '.');
 	var ids = filterByPrefix(tables, '#');
-	return attr && (_.include(classes, attr.class) || _.include(ids, attr.id));
+	return attr && (_.include(classes, attr['class']) || _.include(ids, attr['id']));
 }
 
 function walk(dom, options, result) {


### PR DESCRIPTION
When using Browserify to pack `html-to-text` for use on the client-side, Internet Explorer throws the dreaded `Expected Identifier` error message. There are two items fixed here that corrects that error, allowing `html-to-text` to be used on the client-side when bundled with Browserify.

First, the extraneous comma in the declaration for the `options` object. Second, Internet Explorer really *really* doesn't like using `class` as an identifier, so to access a property named `class`, you should use the named index (square bracket) syntax, which was corrected in the `containsTable` function.

Hope this helps some others!