### PR TITLE
make entity regex less greedy (issue #69)

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -44,7 +44,7 @@ var HTMLEntities = {
 };
 
 exports.decodeHTMLEntities = function decodeHTMLEntities(text) {
-    return text.replace(/&(.+?);/g, function(str, ent) {
+    return text.replace(/&([^&]+);/g, function(str, ent) {
         return String.fromCharCode(ent[0] !== '#' ? HTMLEntities[ent] : ent[1] === 'x' ? parseInt(ent.substr(2),16) : parseInt(ent.substr(1), 10));
     });
 };

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -87,4 +87,13 @@ describe('html-to-text', function() {
     });
   });
 
+  describe('entities', function () {
+    it('does not insert null bytes', function () {
+      var html = '<a href="some-url?a=b&amp;b=c">Testing &amp; Done</a>'
+
+      var result = htmlToText.fromString(html)
+      expect(result).to.equal('Testing & Done [some-url?a=b&b=c]')
+    })
+  })
+
 });


### PR DESCRIPTION
Instead of matching *any* character, match any non-& character. This should fix issue #69, where the string being processed included more than one & character.