### PR TITLE
Preserve newlines in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can configure the behaviour of html-to-text with the following options:
  * `hideLinkHrefIfSameAsText` by default links are translated the following `<a href='link'>text</a>` => becomes => `text [link]`. If this option is set to true and `link` and `text` are the same, `[link]` will be hidden and only `text` visible.
  * `ignoreHref` ignore all document links if `true`.
  * `ignoreImage` ignore all document images if `true`.
+ * `preserveNewlines` by default, any newlines `\n` in a block of text will be removed. If `true`, these newlines will not be removed.
 
 ## Command Line Interface
 

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -10,7 +10,7 @@ function formatText(elem, options) {
 	if (options.isInPre) {
 		return text;
 	} else {
-		return helper.wordwrap(elem.needsSpace ? ' ' + text : text, options.wordwrap);
+		return helper.wordwrap(elem.needsSpace ? ' ' + text : text, options.wordwrap, options.preserveNewlines);
 	}
 }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -49,10 +49,16 @@ exports.decodeHTMLEntities = function decodeHTMLEntities(text) {
     });
 };
 
-exports.wordwrap = function wordwrap(text, max) {
+exports.wordwrap = function wordwrap(text, max, preserveNewlines) {
     // Preserve leading space
     var result = _s.startsWith(text, ' ') ? ' ' : '';
-    var words = _s.words(text);
+    var words;
+    if(!preserveNewlines) {
+      words = _s.words(text);
+    } else {
+      var splittable = text.replace(/\n/g, '\n ');
+      words = splittable.split(/\ +/)
+    }
     var length = result.length;
     var buffer = [];
     _.each(words, function(word) {

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -19,6 +19,7 @@ function htmlToText(html, options) {
 	_.defaults(options, {
 		wordwrap: 80,
 		tables: [],
+		preserveNewlines: false,
 		hideLinkHrefIfSameAsText: false,
 		linkHrefBaseUrl: null
 	});

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -34,7 +34,27 @@ describe('html-to-text', function() {
       it('should not wordwrap when given false', function() {
         expect(htmlToText.fromString(longStr, { wordwrap: false })).to.equal(longStr);
       });
+    });
+    describe('preserveNewlines option', function() {
 
+      var newlineStr;
+
+      beforeEach(function() {
+        newlineStr = '<p\n>One\nTwo\nThree</p>';
+      });
+
+      it('should not preserve newlines by default', function() {
+        expect(htmlToText.fromString(newlineStr)).to.not.contain('\n');
+      });
+
+      it('should preserve newlines when provided with a truthy value', function() {
+        expect(htmlToText.fromString(newlineStr, { preserveNewlines: true })).to.contain('\n');
+      });
+
+      it('should not preserve newlines in the tags themselves', function() {
+        var output_text = htmlToText.fromString(newlineStr, { preserveNewlines: true });
+        expect(output_text.slice(0,1)).to.equal("O");
+      });
     });
   });
 


### PR DESCRIPTION
This will not change anything for current users, but exposes a new option: preserveNewlines, which causes newlines in text to be retained by the output.