### PR TITLE
bugfix: correctly handle HTML entities for images

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -21,7 +21,7 @@ function formatImage(elem, options) {
 
 	var result = '', attribs = elem.attribs || {};
 	if (attribs.alt) {
-		result += attribs.alt;
+		result += helper.decodeHTMLEntities(attribs.alt);
 		if (attribs.src) {
 			result += ' ';
 		}

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -114,6 +114,13 @@ describe('html-to-text', function() {
       var result = htmlToText.fromString(html)
       expect(result).to.equal('Testing & Done [some-url?a=b&b=c]')
     })
+
+    it('should replace entities inside `alt` attributes of images', function () {
+      var html = '<img src="test.png" alt="&quot;Awesome&quot;">'
+
+      var result = htmlToText.fromString(html)
+      expect(result).to.equal('"Awesome" [test.png]')
+    })
   })
 
 });


### PR DESCRIPTION
Currently, HTML entities are not parsed inside the `alt` tag of images.