### PR TITLE
Expose option to not uppercase headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You can configure the behaviour of html-to-text with the following options:
  * `ignoreImage` ignore all document images if `true`.
  * `preserveNewlines` by default, any newlines `\n` in a block of text will be removed. If `true`, these newlines will not be removed.
  * `decodeOptions` defines the text decoding options given to `he.decode`. For more informations see the [he](https://github.com/mathiasbynens/he) module.
+ * `uppercaseHeadings` by default, headings (`<h1>`, `<h2>`, etc) are uppercased. Set to `false` to leave headings as they are.
 
 ## Command Line Interface
 
@@ -274,7 +275,7 @@ Somewhere
 E-Mail: Click here [test@example.com]
 ```
 
-## License 
+## License
 
 (The MIT License)
 

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -42,7 +42,11 @@ function formatParagraph(elem, fn, options) {
 }
 
 function formatHeading(elem, fn, options) {
-	return fn(elem.children, options).toUpperCase() + '\n';
+	var heading = fn(elem.children, options);
+	if (options.uppercaseHeadings) {
+		heading = heading.toUpperCase();
+	}
+	return heading + '\n';
 }
 
 // If we have both href and anchor text, format it in a useful manner:

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -20,6 +20,7 @@ function htmlToText(html, options) {
 		wordwrap: 80,
 		tables: [],
 		preserveNewlines: false,
+		uppercaseHeadings: true,
 		hideLinkHrefIfSameAsText: false,
 		linkHrefBaseUrl: null,
 		decodeOptions: {
@@ -29,13 +30,13 @@ function htmlToText(html, options) {
 	});
 
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
-		
+
 	}, {
 		verbose: true,
 		ignoreWhitespace: true
 	});
 	new htmlparser.Parser(handler).parseComplete(html);
-	
+
 	var result = walk(filterBody(handler.dom), options);
 	return _s.strip(result);
 }


### PR DESCRIPTION
This exposes and option to not uppercase headers (in our case, it was capitalizing django vars which was causing issues). Default set to true. 