### PR TITLE
Add the ability to ignore elements by class or id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules
+
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ console.log(text);
 You can configure the behaviour of html-to-text with the following options:
 
  * `tables` allows to select certain tables by the `class` or `id` attribute from the HTML document. This is necessary because the majority of HTML E-Mails uses a table based layout. Prefix your table selectors with an `.` for the `class` and with a `#` for the `id` attribute. All other tables are ignored. You can assign `true` to this attribute to select all tables. Default: `[]`
+ * `ignored` allows to select certain elements by the `class` or `id` attribute from the HTML document that should be ignored when converting to plaintext. Default: `[]`
  * `wordwrap` defines after how many chars a line break should follow in `p` elements. Set to `null` or `false` to disable word-wrapping. Default: `80`
  * `linkHrefBaseUrl` allows you to specify the server host for href attributes, where the links start at the root (`/`). For example, `linkHrefBaseUrl = 'http://asdf.com'` and `<a href='/dir/subdir'>...</a>` the link in the text will be `http://asdf.com/dir/subdir`. Keep in mind that `linkHrefBaseUrl` shouldn't end with a `/`.
  * `hideLinkHrefIfSameAsText` by default links are translated the following `<a href='link'>text</a>` => becomes => `text [link]`. If this option is set to true and `link` and `text` are the same, `[link]` will be hidden and only `text` visible.

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -19,6 +19,7 @@ function htmlToText(html, options) {
 	_.defaults(options, {
 		wordwrap: 80,
 		tables: [],
+		ignored: [],
 		preserveNewlines: false,
 		uppercaseHeadings: true,
 		hideLinkHrefIfSameAsText: false,
@@ -114,6 +115,39 @@ function containsTable(attr, tables) {
 	});
 	return matched;
 }
+
+function isIgnored(attr, ignored) {
+	function removePrefix(key) {
+		return key.substr(1);
+	}
+	function checkPrefix(prefix) {
+		return function(key) {
+			return _s.startsWith(key, prefix);
+		};
+	}
+	function filterByPrefix(ignored, prefix) {
+		return _(ignored).chain()
+						.filter(checkPrefix(prefix))
+						.map(removePrefix)
+						.value();
+	}
+	var classes = filterByPrefix(ignored, '.');
+	var ids = filterByPrefix(ignored, '#');
+	var tagClasses = (attr['class'] || '').split(' ')
+	var tagIds = (attr['id'] || '').split(' ')
+
+	matched = false
+	_.each(classes, function(aClass) {
+		if (_.include(tagClasses, aClass)) {
+			matched = true;
+		}
+	});
+	_.each(ids, function(anId) {
+		if (_.include(tagIds, anId)) {
+			matched = true;
+		}
+	});
+	return matched;
 }
 
 function walk(dom, options, result) {
@@ -124,6 +158,11 @@ function walk(dom, options, result) {
 	_.each(dom, function(elem) {
 		switch(elem.type) {
 			case 'tag':
+				console.log("ignores", elem.name, elem.attribs, options.ignored);
+				if (isIgnored(elem.attribs, options.ignored)) {
+					console.log('Is Ignored!!!!');
+					return;
+				};
 				switch(elem.name.toLowerCase()) {
 					case 'img':
 						result += format.image(elem, options);

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -158,9 +158,7 @@ function walk(dom, options, result) {
 	_.each(dom, function(elem) {
 		switch(elem.type) {
 			case 'tag':
-				console.log("ignores", elem.name, elem.attribs, options.ignored);
 				if (isIgnored(elem.attribs, options.ignored)) {
-					console.log('Is Ignored!!!!');
 					return;
 				};
 				switch(elem.name.toLowerCase()) {

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -83,6 +83,10 @@ function filterBody(dom, options, baseElement) {
 function containsTable(attr, tables) {
 	if (tables === true) return true;
 
+	if (!attr) {
+		return false;
+	}
+
 	function removePrefix(key) {
 		return key.substr(1);
 	}
@@ -117,6 +121,10 @@ function containsTable(attr, tables) {
 }
 
 function isIgnored(attr, ignored) {
+	if (!attr) {
+		return false;
+	}
+
 	function removePrefix(key) {
 		return key.substr(1);
 	}

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -98,7 +98,22 @@ function containsTable(attr, tables) {
 	}
 	var classes = filterByPrefix(tables, '.');
 	var ids = filterByPrefix(tables, '#');
-	return attr && (_.include(classes, attr['class']) || _.include(ids, attr['id']));
+	var tagClasses = (attr['class'] || '').split(' ')
+	var tagIds = (attr['id'] || '').split(' ')
+
+	matched = false
+	_.each(classes, function(aClass) {
+		if (_.include(tagClasses, aClass)) {
+			matched = true;
+		}
+	});
+	_.each(ids, function(anId) {
+		if (_.include(tagIds, anId)) {
+			matched = true;
+		}
+	});
+	return matched;
+}
 }
 
 function walk(dom, options, result) {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "htmlparser": "^1.7.7",
     "optimist": "^0.6.1",
     "underscore": "^1.8.3",
-    "underscore.string": "^3.2.3",
-    "html-to-text": "git://github.com/duanefields/node-html-to-text"
+    "underscore.string": "^3.2.3"
   },
   "keywords": [
     "html",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "htmlparser": "^1.7.7",
     "optimist": "^0.6.1",
     "underscore": "^1.8.3",
-    "underscore.string": "^3.2.3"
+    "underscore.string": "^3.2.3",
+    "html-to-text": "git://github.com/duanefields/node-html-to-text"
   },
   "keywords": [
     "html",


### PR DESCRIPTION
Adds the ability to ignore elements by class or id, so you can remove entire elements from the plaintext version. Also fixes an issue where "table" elements where not being matched if the target element had multiple class attributes.
