### PR TITLE
Prevent extra whitespace from being added (fix #88)

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -5,13 +5,13 @@ var he = require('he');
 var helper = require('./helper');
 
 function formatText(elem, options) {
-	var text = (options.isInPre ? elem.raw : _s.strip(elem.raw));
+	var text = elem.raw;
 	text = he.decode(text, options.decodeOptions);
 
 	if (options.isInPre) {
 		return text;
 	} else {
-		return helper.wordwrap(elem.needsSpace ? ' ' + text : text, options);
+		return helper.wordwrap(elem.trimLeadingSpace ? _s.lstrip(text) : text, options);
 	}
 }
 
@@ -58,10 +58,12 @@ function formatAnchor(elem, fn, options) {
 	var href = '';
 	// Always get the anchor text
 	var storedCharCount = options.lineCharCount;
-	var result = _s.strip(fn(elem.children || [], options));
-	if (!result) {
-		result = '';
+	var text = fn(elem.children || [], options);
+	if (!text) {
+		text = '';
 	}
+
+	var result = elem.trimLeadingSpace ? _s.lstrip(text) : text;
 
 	if (!options.ignoreHref) {
 		// Get the href, if present
@@ -72,7 +74,7 @@ function formatAnchor(elem, fn, options) {
 			if (options.linkHrefBaseUrl && href.indexOf('/') == 0) {
 				href = options.linkHrefBaseUrl + href;
 			}
-			if (!options.hideLinkHrefIfSameAsText || href != result.replace('\n', '')) {
+			if (!options.hideLinkHrefIfSameAsText || href != _s.replaceAll(result, '\n', '')) {
 				result += ' [' + href + ']';
 			}
 		}
@@ -80,7 +82,7 @@ function formatAnchor(elem, fn, options) {
 
 	options.lineCharCount = storedCharCount;
 
-	return formatText({ raw: result || href, needsSpace: elem.needsSpace }, options);
+	return formatText({ raw: result || href, trimLeadingSpace: elem.trimLeadingSpace }, options);
 }
 
 function formatHorizontalLine(elem, fn, options) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -66,7 +66,7 @@ exports.wordwrap = function wordwrap(text, options) {
     // Determine where to end line word by word.
     _.each(words, function(word) {
         // Add buffer to result if we can't fit any more words in the buffer.
-        if ((max || max === 0) &&
+        if ((max || max === 0) && length > 0 &&
             ((length + word.length > max) || (length + word.indexOf('\n') > max)))
         {
             // Concat buffer and add it to the result
@@ -101,7 +101,15 @@ exports.wordwrap = function wordwrap(text, options) {
     });
     // Add the rest to the result.
     result += buffer.join(' ');
-    return _s.rstrip(result);
+
+    // Preserve trailing space
+    if (!_s.endsWith(text, ' ')) {
+      result = _s.rtrim(result);
+    } else if (!_s.endsWith(result, ' ')) {
+      result = result + ' ';
+    }
+
+    return result;
 };
 
 exports.arrayZip = function arrayZip(array) {

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -105,7 +105,7 @@ function walk(dom, options, result) {
 	if (arguments.length < 3) {
 		result = '';
 	}
-	var whiteSpaceRegex = /\S$/;
+	var whiteSpaceRegex = /\s$/;
 	_.each(dom, function(elem) {
 		switch(elem.type) {
 			case 'tag':
@@ -114,9 +114,9 @@ function walk(dom, options, result) {
 						result += format.image(elem, options);
 						break;
 					case 'a':
-						// Inline element needs a leading space if `result` currently
-						// doesn't end with whitespace
-						elem.needsSpace = whiteSpaceRegex.test(result);
+						// Inline element needs its leading space to be trimmed if `result`
+						// currently ends with whitespace
+						elem.trimLeadingSpace = whiteSpaceRegex.test(result);
 						result += format.anchor(elem, walk, options);
 						break;
 					case 'p':
@@ -158,9 +158,9 @@ function walk(dom, options, result) {
 				break;
 			case 'text':
 				if (elem.raw !== '\r\n') {
-					// Text needs a leading space if `result` currently
-					// doesn't end with whitespace
-					elem.needsSpace = whiteSpaceRegex.test(result);
+					// Text needs its leading space to be trimmed if `result`
+					// currently ends with whitespace
+					elem.trimLeadingSpace = whiteSpaceRegex.test(result);
 					result += format.text(elem, options);
 				}
 				break;

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -52,7 +52,7 @@ describe('html-to-text', function() {
 
       it('should not exceed the line width when processing anchor tags', function() {
         var testString = "<p>We appreciate your business. And we hope you'll check out our <a href=\"http://example.com/\">new products</a>!</p>";
-        expect(htmlToText.fromString(testString, {} )).to.equal('We appreciate your business. And we hope you\'ll check out our new products\n[http://example.com/] !');
+        expect(htmlToText.fromString(testString, {} )).to.equal('We appreciate your business. And we hope you\'ll check out our new products\n[http://example.com/]!');
       });
 
       it('should honour line feeds from a long word across the wrap, where the line feed is before the wrap', function() {
@@ -145,7 +145,7 @@ describe('html-to-text', function() {
           <li>run in the park <span style="color:#888888;">(in progress)</span></li> \
         </ul> \
       ';
-      var resultExpected = 'Good morning Jacob,Lorem ipsum dolor sit amet\n\nLorem ipsum dolor sit amet.\n\n * run in the park (in progress)';
+      var resultExpected = 'Good morning Jacob, Lorem ipsum dolor sit amet\n\nLorem ipsum dolor sit amet.\n\n * run in the park (in progress)';
       var result = htmlToText.fromString(html, { wordwrap: false });
       expect(result).to.equal(resultExpected);
     });
@@ -164,7 +164,7 @@ describe('html-to-text', function() {
         </TBODY> \
         </TABLE> \
       ';
-      var resultExpected = 'Good morning Jacob,Lorem ipsum dolor sit amet.';
+      var resultExpected = 'Good morning Jacob, Lorem ipsum dolor sit amet.';
       var result = htmlToText.fromString(html, { tables: true });
       expect(result).to.equal(resultExpected);
     });

--- a/test/test.html
+++ b/test/test.html
@@ -15,7 +15,7 @@
 			<tr>
 				<td>
 					<h2>Paragraphs</h2>
-					<p class="normal-space">At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. <a href="www.github.com">Github</a>
+					<p class="normal-space">At vero eos et accu<strong>sam</strong> et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. <a href="www.github.com">Github</a>
 					</p>
 					<p class="normal-space">At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 					</p>

--- a/test/test.txt
+++ b/test/test.txt
@@ -58,4 +58,4 @@ Somewhere
 E-Mail: Click here [test@example.com]
 
 We appreciate your business. And we hope you'll check out our new products
-[http://example.com/] !
+[http://example.com/]!


### PR DESCRIPTION
`foo<strong>bar</strong>` will now be converted to `foobar` (no extra whitespace).

Previously, any block of text or `<a>` tag would introduce leading whitespace (unless already parsed text ends with one). With these changes, extra leading whitespace is never added. Instead, trailing whitespace is preserved, and leading whitespace is removed if it would result in double whitespace.

One anomaly I found is that text followed by a paragraph would result in nothing between the two. I didn't fix this deliberately, but as a side-effect of the fix for the issue described above, an extra whitespace is now added to the end of the first line, e.g.

`foo<p>bar</p>` results in `foo bar` (it used to render as `foobar`).

I don't think this new behaviour is incorrect, but most likely the proper fix would be to introduce a newline character.