### PR TITLE
Do not ignore whitespace nodes

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -107,7 +107,7 @@ var whiteSpaceRegex = /^\s*$/;
 
 function formatUnorderedList(elem, fn, options) {
 	var result = '';
-	var nonWhiteSpaceChildren = elem.children.filter(function(child) {
+	var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
 		return child.type !== 'text' || !whiteSpaceRegex.test(child.raw);
 	});
 	_.each(nonWhiteSpaceChildren, function(elem) {
@@ -118,7 +118,7 @@ function formatUnorderedList(elem, fn, options) {
 
 function formatOrderedList(elem, fn, options) {
 	var result = '';
-	var nonWhiteSpaceChildren = elem.children.filter(function(child) {
+	var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
 		return child.type !== 'text' || !whiteSpaceRegex.test(child.raw);
 	});
 	// Make sure there are list items present

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -103,9 +103,14 @@ function formatListItem(prefix, elem, fn, options) {
 	return prefix + text + '\n';
 }
 
+var whiteSpaceRegex = /^\s*$/;
+
 function formatUnorderedList(elem, fn, options) {
 	var result = '';
-	_.each(elem.children, function(elem) {
+	var nonWhiteSpaceChildren = elem.children.filter(function(child) {
+		return child.type !== 'text' || !whiteSpaceRegex.test(child.raw);
+	});
+	_.each(nonWhiteSpaceChildren, function(elem) {
 		result += formatListItem(' * ', elem, fn, options);
 	});
 	return result + '\n';
@@ -113,11 +118,14 @@ function formatUnorderedList(elem, fn, options) {
 
 function formatOrderedList(elem, fn, options) {
 	var result = '';
+	var nonWhiteSpaceChildren = elem.children.filter(function(child) {
+		return child.type !== 'text' || !whiteSpaceRegex.test(child.raw);
+	});
 	// Make sure there are list items present
-	if (elem.children && elem.children.length) {
+	if (nonWhiteSpaceChildren.length) {
 		// Calculate the maximum length to i.
-		var maxLength = elem.children.length.toString().length;
-		_.each(elem.children, function(elem, i) {
+		var maxLength = nonWhiteSpaceChildren.length.toString().length;
+		_.each(nonWhiteSpaceChildren, function(elem, i) {
 			var index = i + 1;
 			// Calculate the needed spacing for nice indentation.
 			var spacing = maxLength - index.toString().length;

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -38,8 +38,7 @@ function htmlToText(html, options) {
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
 
 	}, {
-		verbose: true,
-		ignoreWhitespace: true
+		verbose: true
 	});
 	new htmlparser.Parser(handler).parseComplete(html);
 

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -170,6 +170,18 @@ describe('html-to-text', function() {
     });
   });
 
+  describe('lists', function() {
+    it('should handle empty unordered lists', function() {
+      var testString = '<ul></ul>';
+      expect(htmlToText.fromString(testString)).to.equal('');
+    });
+
+    it('should handle empty ordered lists', function() {
+      var testString = '<ol></ol>';
+      expect(htmlToText.fromString(testString)).to.equal('');
+    });
+  });
+
   describe('entities', function () {
     it('does not insert null bytes', function () {
       var html = '<a href="some-url?a=b&amp;b=c">Testing &amp; Done</a>';

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -414,5 +414,12 @@ describe('html-to-text', function() {
       expect(htmlToText.fromString(testString, { hideLinkHrefIfSameAsText: false, longWordSplit: { wrapCharacters: ['/', '_'], forceWrapOnLimit: false }} ))
           .to.equal('http://images.fb.com/2015/12/21/\nivete-sangalo-launches-360-music-video-on-facebook/\n[http://images.fb.com/2015/12/21/\nivete-sangalo-launches-360-music-video-on-facebook/]');
     });
-  })
+  });
+
+  describe('whitespace', function() {
+    it('should not be ignored inside a whitespace-only node', function() {
+      var testString = 'foo<span> </span>bar';
+      expect(htmlToText.fromString(testString)).to.equal('foo bar');
+    });
+  });
 });


### PR DESCRIPTION
In #99 I've introduced a bug where `foo<span> </span>bar` would be formatted without any whitespace (`foobar` instead of `foo bar`). Parser was set up to ignore all whitespace-only html nodes; however, as previously a space was always added before any node, this wasn't an issue.
I've changed parser settings not to ignore any nodes. As both list formatters started generating a new item for whitespace nodes, I had to filter those out. I've also added tests to make sure that empty lists (`<ul></ul>` `<ol></ol>`) are handled correctly.