### PR TITLE
Convert video tags to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You can configure the behaviour of html-to-text with the following options:
  * `hideLinkHrefIfSameAsText` by default links are translated the following `<a href='link'>text</a>` => becomes => `text [link]`. If this option is set to true and `link` and `text` are the same, `[link]` will be hidden and only `text` visible.
  * `ignoreHref` ignore all document links if `true`.
  * `ignoreImage` ignore all document images if `true`.
+ * `ignoreVideo` ignore all document videos if `true`.
  * `preserveNewlines` by default, any newlines `\n` in a block of text will be removed. If `true`, these newlines will not be removed.
  * `decodeOptions` defines the text decoding options given to `he.decode`. For more informations see the [he](https://github.com/mathiasbynens/he) module.
  * `uppercaseHeadings` by default, headings (`<h1>`, `<h2>`, etc) are uppercased. Set to `false` to leave headings as they are.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,6 +8,7 @@ var argv = optimist
 	.default('wordwrap', 80)
 	.default('ignore-href', false)
 	.default('ignore-image', false)
+	.default('ignore-video', false)
 	.argv;
 
 var text = '';
@@ -25,7 +26,8 @@ process.stdin.on('end', function end() {
 		tables: interpretTables(argv.tables),
 		wordwrap: argv.wordwrap,
 		ignoreHref: argv['ignore-href'],
-		ignoreImage: argv['ignore-image']
+		ignoreImage: argv['ignore-image'],
+		ignoreVideo: argv['ignore-video']
 	});
 	process.stdout.write(text + '\n', 'utf-8');
 });

--- a/example/test.html
+++ b/example/test.html
@@ -142,5 +142,19 @@ htmlToText.fromFile(path.join(__dirname, 'test.html'), {
 	console.log(text);
 });
 		</pre>
+
+		<hr />
+		<h2>Img tag</h2>
+		<img src="http://example.com/image" />
+
+		<hr />
+		<h2>Video tag (src attribute)</h2>
+		<video src="http://example.com/video-with-src-attribute"></video>
+
+		<hr />
+		<h2>Video tag (source tag)</h2>
+		<video>
+			<source src="http://example.com/video-with-source-tag">
+		</video>
 	</body>
 </html>

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -34,10 +34,9 @@ function formatImage(elem, options) {
 }
 
 function formatVideo(elem, options) {
-  // Uncomment once we have an ignoreVideo option
-  //if (options.ignoreVideo) {
-  //  return '';
-  //}
+	if (options.ignoreVideo) {
+	  return '';
+	}
 
 	var result = '', attribs = elem.attribs || {};
 	if (attribs.alt) {

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -39,12 +39,6 @@ function formatVideo(elem, options) {
 	}
 
 	var result = '', attribs = elem.attribs || {};
-	if (attribs.alt) {
-		result += he.decode(attribs.alt, options.decodeOptions);
-		if (attribs.src) {
-			result += ' ';
-		}
-	}
 	if (attribs.src) {
 		result += '[' + attribs.src + ']';
 	}

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -33,6 +33,25 @@ function formatImage(elem, options) {
 	return (result);
 }
 
+function formatVideo(elem, options) {
+  // Uncomment once we have an ignoreVideo option
+  //if (options.ignoreVideo) {
+  //  return '';
+  //}
+
+	var result = '', attribs = elem.attribs || {};
+	if (attribs.alt) {
+		result += he.decode(attribs.alt, options.decodeOptions);
+		if (attribs.src) {
+			result += ' ';
+		}
+	}
+	if (attribs.src) {
+		result += '[' + attribs.src + ']';
+	}
+	return (result);
+}
+
 function formatLineBreak(elem, fn, options) {
 	return '\n' + fn(elem.children, options);
 }
@@ -219,6 +238,7 @@ function formatTable(elem, fn, options) {
 
 exports.text = formatText;
 exports.image = formatImage;
+exports.video = formatVideo;
 exports.lineBreak = formatLineBreak;
 exports.paragraph = formatParagraph;
 exports.anchor = formatAnchor;

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -39,9 +39,18 @@ function formatVideo(elem, options) {
 	}
 
 	var result = '', attribs = elem.attribs || {};
+
 	if (attribs.src) {
 		result += '[' + attribs.src + ']';
+	} else if (elem.children.length > 0) {
+		_.each(elem.children, function(el) {
+			var elAttribs = el.attribs || {};
+			if (el.type === 'tag' && el.name.toLowerCase() === 'source') {
+				result += '[' + el.attribs.src + ']';
+			}
+		});
 	}
+
 	return (result);
 }
 

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -112,6 +112,9 @@ function walk(dom, options, result) {
 					case 'img':
 						result += format.image(elem, options);
 						break;
+					case 'video':
+						result += format.video(elem, options);
+						break;
 					case 'a':
 						// Inline element needs its leading space to be trimmed if `result`
 						// currently ends with whitespace


### PR DESCRIPTION
Currently, node-html-to-text ignores `video` tags. This adds support for `video` tags similar to `img` tags.

So if a video is encountered in either of these formats, with a `src` attribute or `source` tag...

```html
<video src="http://example.com/a.mp4">
```

```html
<video>
  <source src="http://example.com/a.mp4">
<video>
```

...it will output a bracketed link to the video:

```
[http://example.com/a.mp4]
```

It also adds an `ignoreVideo` option that works the same way as `ignoreImage`.

This would resolve issue #103.

My team is finding your library very useful. Thanks for creating it! 