### PR TITLE
Treat non-numeric colspans as zero and handle them gracefully

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -196,7 +196,7 @@ function formatTable(elem, fn, options) {
 								rows.push(_.compact(tokens));
 								// Fill colspans with empty values
 								if (elem.attribs && elem.attribs.colspan) {
-									times = elem.attribs.colspan - 1;
+									times = elem.attribs.colspan - 1 || 0;
 									_.times(times, function() {
 										rows.push(['']);
 									});

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -168,6 +168,23 @@ describe('html-to-text', function() {
       var result = htmlToText.fromString(html, { tables: true });
       expect(result).to.equal(resultExpected);
     });
+
+    it('does handle non-integer colspan on td element gracefully', function () {
+      var html = 'Good morning Jacob, \
+        <TABLE> \
+        <CENTER> \
+        <TBODY> \
+        <TR> \
+        <TD colspan="abc">Lorem ipsum dolor sit amet.</TD> \
+        </TR> \
+        </CENTER> \
+        </TBODY> \
+        </TABLE> \
+      ';
+      var resultExpected = 'Good morning Jacob, Lorem ipsum dolor sit amet.';
+      var result = htmlToText.fromString(html, { tables: true });
+      expect(result).to.equal(resultExpected);
+    });
   });
 
   describe('lists', function() {


### PR DESCRIPTION
When colspan is not a numeric value, filling of empty columns will fail when attempting to calculate how many columns need to be filled.

We noticed this after recieving email with 
``` html
<table>
  <tr>
    <td colspan="100%">Some arbitrary text</td>
  </tr>
  <tr>
    <td colspan="100%" style="font-size: 14px">Some more arbitrary text</td>
  </tr>
</table>
```
Which when attempting to parse them results in
```
RangeError: Invalid array length
```