### PR TITLE
Option to format paragraph with single new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can configure the behaviour of html-to-text with the following options:
  * `preserveNewlines` by default, any newlines `\n` in a block of text will be removed. If `true`, these newlines will not be removed.
  * `decodeOptions` defines the text decoding options given to `he.decode`. For more informations see the [he](https://github.com/mathiasbynens/he) module.
  * `uppercaseHeadings` by default, headings (`<h1>`, `<h2>`, etc) are uppercased. Set to `false` to leave headings as they are.
+ * `singleNewLineParagraphs` by default, paragraphs are converted with two newlines (`\n\n`). Set to `true` to convert to a single newline.
  * `baseElement` defines the tags whose text content will be captured from the html.  All content will be captured below the baseElement tags and added to the resulting text output.  This option allows the user to specify an array of elements as base elements using a single tag with css class and id parameters e.g. [`p.class1.class2#id1#id2`, `p.class1.class2#id1#id2`]  .  Default: `body`
  * `returnDomByDefault` convert the entire document if we don't find the tag we're looking for if `true`.
  * `longWordSplit` describes how to wrap long words, has the following parameters:

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -38,7 +38,12 @@ function formatLineBreak(elem, fn, options) {
 }
 
 function formatParagraph(elem, fn, options) {
-	return fn(elem.children, options) + '\n\n';
+	var paragraph = fn(elem.children, options)
+	if (options.singleNewLineParagraphs) {
+		return paragraph + '\n'
+	} else {
+		return paragraph + '\n\n'
+	}
 }
 
 function formatHeading(elem, fn, options) {

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -21,6 +21,7 @@ function htmlToText(html, options) {
 		tables: [],
 		preserveNewlines: false,
 		uppercaseHeadings: true,
+		singleNewLineParagraphs: false,
 		hideLinkHrefIfSameAsText: false,
 		linkHrefBaseUrl: null,
 		baseElement: 'body',

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -119,6 +119,27 @@ describe('html-to-text', function() {
             .to.equal('If a word with a line feed exists over the line feed boundary then you must\nrespect it.');
       });
     });
+
+    describe('single line paragraph option', function() {
+
+      var paragraphsString;
+
+      beforeEach(function() {
+        paragraphsString = '<p>First</p><p>Second</p>';
+      });
+
+      it('should not use single new line when given null', function() {
+        expect(htmlToText.fromString(paragraphsString, { singleNewLineParagraphs: null } )).to.equal('First\n\nSecond');
+      });
+
+      it('should not use single new line when given false', function() {
+        expect(htmlToText.fromString(paragraphsString, { singleNewLineParagraphs: false } )).to.equal('First\n\nSecond');
+      });
+
+      it('should use single new line when given true', function() {
+        expect(htmlToText.fromString(paragraphsString, { singleNewLineParagraphs: true } )).to.equal('First\nSecond');
+      });
+    });
   });
 
   describe('.fromFile()', function() {


### PR DESCRIPTION
Currently paragraphs are converted with a single line, ie.

```
<p>First paragraph</p><p>Second paragraph</p>
```

becomes

```
First paragraph

Second paragraph
```

With the option I have added it is possible to get

```
First paragraph
Second paragraph
```

I have the need to do this because sometimes emails I receive and want to convert have paragraphs `<p>`instead of line breaks `<br>` in them. Most email clients show them with a single line break instead of two and thus I want to do the same.
