### PR TITLE
add basic support for alpha ordered list types

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -130,6 +130,14 @@ function formatOrderedList(elem, fn, options) {
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
   });
+  // Return different functions for different OL types
+  var typeFunctions = {
+    1: function(start, i) { return i + 1 + start},
+    a: function(start, i) { return String.fromCharCode(i + start + 97)},
+    A: function(start, i) { return String.fromCharCode(i + start + 65)}
+  };
+  // Determine type
+  var olType = elem.attribs.type || '1'
   // Make sure there are list items present
   if (nonWhiteSpaceChildren.length) {
     // Calculate initial start from ol attribute
@@ -137,10 +145,11 @@ function formatOrderedList(elem, fn, options) {
     // Calculate the maximum length to i.
     var maxLength = (nonWhiteSpaceChildren.length + start).toString().length;
     _.each(nonWhiteSpaceChildren, function(elem, i) {
-      var index = i + 1 + start;
+      // Use different function depending on type
+      var index = typeFunctions[olType](start, i);
       // Calculate the needed spacing for nice indentation.
       var spacing = maxLength - index.toString().length;
-      var prefix = ' ' + index + '. ' + _s.repeat(' ', spacing);
+      var prefix = (olType === '1') ? ' ' + index + '. ' + _s.repeat(' ', spacing) : index + '. ';
       result += formatListItem(prefix, elem, fn, options);
     });
   }

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -232,6 +232,16 @@ describe('html-to-text', function() {
         expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
       });
 
+      it('should support the ordered list type="a" attribute', function() {
+        var testString = '<ol type="a"><li>foo</li><li>bar</li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal('a. foo\nb. bar');
+      });
+
+      it('should support the ordered list type="A" attribute', function() {
+        var testString = '<ol type="A"><li>foo</li><li>bar</li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal('A. foo\nB. bar');
+      });
+
       it('should support the ordered list start attribute', function() {
         var testString = '<ol start="2"><li>foo</li><li>bar</li></ol>';
         expect(htmlToText.fromString(testString)).to.equal('2. foo\n 3. bar');

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -232,6 +232,11 @@ describe('html-to-text', function() {
         expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
       });
 
+      it('should support the ordered list type="1" attribute', function() {
+        var testString = '<ol type="1"><li>foo</li><li>bar</li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+      });
+
       it('should support the ordered list type="a" attribute', function() {
         var testString = '<ol type="a"><li>foo</li><li>bar</li></ol>';
         expect(htmlToText.fromString(testString)).to.equal('a. foo\nb. bar');
@@ -246,6 +251,21 @@ describe('html-to-text', function() {
         var testString = '<ol start="2"><li>foo</li><li>bar</li></ol>';
         expect(htmlToText.fromString(testString)).to.equal('2. foo\n 3. bar');
       });
+
+      /*
+       * Currently failing tests for continuing to fill out the specification
+       *  Spec: https://html.spec.whatwg.org/multipage/semantics.html#the-ol-element
+       *
+      it('should support the ordered list type="a" attribute past 26 characters', function() {
+        var testString = '<ol start="26" type="a"><li>foo</li><li>bar</li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal('z. foo\naa. bar');
+      });
+
+      it('should support the ordered list type="A" attribute past 26 characters', function() {
+        var testString = '<ol start="26" type="A"><li>foo</li><li>bar</li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal('Z. foo\nAA. bar');
+      });
+      */
     });
 
     it('doesnt wrap li if wordwrap isnt', function () {


### PR DESCRIPTION
Supporting `type="a"` and `type="A"` as per:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol