### PR TITLE
Implement ol type="i" and "I" as fallbacks to "1", add option to not render anchor links.

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -131,17 +131,18 @@ function formatOrderedList(elem, fn, options) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
   });
   // Return different functions for different OL types
-  var typeFunctions = {
-    1: function(start, i) { return i + 1 + start},
-    a: function(start, i) { return String.fromCharCode(i + start + 97)},
-    A: function(start, i) { return String.fromCharCode(i + start + 65)}
-  };
-  // TODO Imeplement the other valid types
-  //   Fallback to type '1' function for other valid types
-  typeFunctions.i = typeFunctions['1'];
-  typeFunctions.I = typeFunctions['1'];
-  // Determine ype
-  var olType = elem.attribs.type || '1';
+  var typeFunction = (function() {
+    // Determine type
+    var olType = elem.attribs.type || '1';
+    // TODO Imeplement the other valid types
+    //   Fallback to type '1' function for other valid types
+    switch(olType) {
+      case 'a': return function(start, i) { return String.fromCharCode(i + start + 97)};
+      case 'A': return function(start, i) { return String.fromCharCode(i + start + 65)};
+      case '1':
+      default: return function(start, i) { return i + 1 + start};
+    }
+  }())
   // Make sure there are list items present
   if (nonWhiteSpaceChildren.length) {
     // Calculate initial start from ol attribute
@@ -150,7 +151,7 @@ function formatOrderedList(elem, fn, options) {
     var maxLength = (nonWhiteSpaceChildren.length + start).toString().length;
     _.each(nonWhiteSpaceChildren, function(elem, i) {
       // Use different function depending on type
-      var index = typeFunctions[olType](start, i);
+      var index = typeFunction(start, i);
       // Calculate the needed spacing for nice indentation.
       var spacing = maxLength - index.toString().length;
       var prefix = ' ' + index + '. ' + _s.repeat(' ', spacing);

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -136,12 +136,16 @@ function formatOrderedList(elem, fn, options) {
     a: function(start, i) { return String.fromCharCode(i + start + 97)},
     A: function(start, i) { return String.fromCharCode(i + start + 65)}
   };
-  // Determine type
-  var olType = elem.attribs.type || '1'
+  // TODO Imeplement the other valid types
+  //   Fallback to type '1' function for other valid types
+  typeFunctions.i = typeFunctions['1'];
+  typeFunctions.I = typeFunctions['1'];
+  // Determine ype
+  var olType = elem.attribs.type || '1';
   // Make sure there are list items present
   if (nonWhiteSpaceChildren.length) {
     // Calculate initial start from ol attribute
-    var start = Number(elem.attribs.start || '1') - 1
+    var start = Number(elem.attribs.start || '1') - 1;
     // Calculate the maximum length to i.
     var maxLength = (nonWhiteSpaceChildren.length + start).toString().length;
     _.each(nonWhiteSpaceChildren, function(elem, i) {
@@ -149,7 +153,7 @@ function formatOrderedList(elem, fn, options) {
       var index = typeFunctions[olType](start, i);
       // Calculate the needed spacing for nice indentation.
       var spacing = maxLength - index.toString().length;
-      var prefix = (olType === '1') ? ' ' + index + '. ' + _s.repeat(' ', spacing) : index + '. ';
+      var prefix = ' ' + index + '. ' + _s.repeat(' ', spacing);
       result += formatListItem(prefix, elem, fn, options);
     });
   }

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -76,14 +76,16 @@ function formatAnchor(elem, fn, options) {
       href = elem.attribs.href.replace(/^mailto\:/, '');
     }
     if (href) {
-      if (options.linkHrefBaseUrl && href.indexOf('/') === 0) {
-        href = options.linkHrefBaseUrl + href;
-      }
-      if (!options.hideLinkHrefIfSameAsText || href !== _s.replaceAll(result, '\n', '')) {
-        if (!options.noLinkBrackets) {
-          result += ' [' + href + ']';
-        } else {
-          result += ' ' + href;
+      if ((!options.noAnchorUrl) || (options.noAnchorUrl && href.indexOf('#') === -1)) {
+        if (options.linkHrefBaseUrl && href.indexOf('/') === 0) {
+          href = options.linkHrefBaseUrl + href;
+        }
+        if (!options.hideLinkHrefIfSameAsText || href !== _s.replaceAll(result, '\n', '')) {
+          if (!options.noLinkBrackets) {
+            result += ' [' + href + ']';
+          } else {
+            result += ' ' + href;
+          }
         }
       }
     }

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -25,6 +25,7 @@ function htmlToText(html, options) {
     hideLinkHrefIfSameAsText: false,
     linkHrefBaseUrl: null,
     noLinkBrackets: false,
+    noAnchorUrl: true,
     baseElement: 'body',
     returnDomByDefault: true,
     decodeOptions: {

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -239,12 +239,26 @@ describe('html-to-text', function() {
 
       it('should support the ordered list type="a" attribute', function() {
         var testString = '<ol type="a"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('a. foo\nb. bar');
+        expect(htmlToText.fromString(testString)).to.equal('a. foo\n b. bar');
       });
 
       it('should support the ordered list type="A" attribute', function() {
         var testString = '<ol type="A"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('A. foo\nB. bar');
+        expect(htmlToText.fromString(testString)).to.equal('A. foo\n B. bar');
+      });
+
+      it('should support the ordered list type="i" attribute by falling back to type="1"', function() {
+        var testString = '<ol type="i"><li>foo</li><li>bar</li></ol>';
+        // TODO Implement lowercase roman numerals
+        // expect(htmlToText.fromString(testString)).to.equal('i. foo\nii. bar');
+        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+      });
+
+      it('should support the ordered list type="I" attribute by falling back to type="1"', function() {
+        var testString = '<ol type="I"><li>foo</li><li>bar</li></ol>';
+        // TODO Implement uppercase roman numerals
+        // expect(htmlToText.fromString(testString)).to.equal('I. foo\nII. bar');
+        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
       });
 
       it('should support the ordered list start attribute', function() {

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -237,6 +237,11 @@ describe('html-to-text', function() {
         expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
       });
 
+      it('should fallback to type="!" behavior if type attribute is invalid', function() {
+        var testString = '<ol type="1"><li>foo</li><li>bar</li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+      });
+
       it('should support the ordered list type="a" attribute', function() {
         var testString = '<ol type="a"><li>foo</li><li>bar</li></ol>';
         expect(htmlToText.fromString(testString)).to.equal('a. foo\n b. bar');

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -206,6 +206,20 @@ describe('html-to-text', function() {
       });
       expect(result).to.equal('test http://my.link');
     });
+
+    it('should not return link for anchor if noAnchorUrl is set to true', function () {
+      var result = htmlToText.fromString('<a href="#link">test</a>', {
+        noAnchorUrl: true
+      });
+      expect(result).to.equal('test');
+    });
+
+    it('should return link for anchor if noAnchorUrl is set to false', function () {
+      var result = htmlToText.fromString('<a href="#link">test</a>', {
+        noAnchorUrl: false
+      });
+      expect(result).to.equal('test [#link]');
+    });
   });
 
   describe('lists', function() {


### PR DESCRIPTION
  * Cleanup semicolon style
  * Fix indentation on OL LIs

Stubbed out i and I so that they don't throw an exception when encountered, making them fallback to `type="1"`

  * added `noAnchorUrl` option to prevent rendering of anchor links (e.g. in-document ToC)