### PR TITLE
dont trim leading whitespace off result, only trailing

### DIFF
--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -53,7 +53,7 @@ function htmlToText(html, options) {
   for (var idx = 0; idx < baseElements.length; ++idx) {
     result += walk(filterBody(handler.dom, options, baseElements[idx]), options);
   }
-  return _s.strip(result);
+  return _s.rtrim(result);
 }
 
 function filterBody(dom, options, baseElement) {

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -231,7 +231,7 @@ describe('html-to-text', function() {
 
       it('should handle an unordered list with multiple elements', function() {
         var testString = '<ul><li>foo</li><li>bar</li></ul>';
-        expect(htmlToText.fromString(testString)).to.equal('* foo\n * bar');
+        expect(htmlToText.fromString(testString)).to.equal(' * foo\n * bar');
       });
     });
 
@@ -243,46 +243,46 @@ describe('html-to-text', function() {
 
       it('should handle an ordered list with multiple elements', function() {
         var testString = '<ol><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list type="1" attribute', function() {
         var testString = '<ol type="1"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should fallback to type="!" behavior if type attribute is invalid', function() {
         var testString = '<ol type="1"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list type="a" attribute', function() {
         var testString = '<ol type="a"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('a. foo\n b. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' a. foo\n b. bar');
       });
 
       it('should support the ordered list type="A" attribute', function() {
         var testString = '<ol type="A"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('A. foo\n B. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' A. foo\n B. bar');
       });
 
       it('should support the ordered list type="i" attribute by falling back to type="1"', function() {
         var testString = '<ol type="i"><li>foo</li><li>bar</li></ol>';
         // TODO Implement lowercase roman numerals
         // expect(htmlToText.fromString(testString)).to.equal('i. foo\nii. bar');
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list type="I" attribute by falling back to type="1"', function() {
         var testString = '<ol type="I"><li>foo</li><li>bar</li></ol>';
         // TODO Implement uppercase roman numerals
         // expect(htmlToText.fromString(testString)).to.equal('I. foo\nII. bar');
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list start attribute', function() {
         var testString = '<ol start="2"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('2. foo\n 3. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 2. foo\n 3. bar');
       });
 
       /*


### PR DESCRIPTION
 - wont break list indentation

The changes to the tests show what is changing.

This:`<ul><li>A</li><li>B</li></ul>` was being formatted as this: (note the misalignment) 

```
* A
 * B
```
Now it will be formatted as this:
```
 * A
 * B
```

The trailing whitespace is still trimmed from the result, but leading whitespace shouldn't be there in the first place unless it is supposed to be.