### PR TITLE
Option to supply custom unordered list item prefix

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -118,11 +118,12 @@ var whiteSpaceRegex = /^\s*$/;
 
 function formatUnorderedList(elem, fn, options) {
   var result = '';
+  var prefix = options.unorderedListItemPrefix;
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
   });
   _.each(nonWhiteSpaceChildren, function(elem) {
-    result += formatListItem(' * ', elem, fn, options);
+    result += formatListItem(prefix, elem, fn, options);
   });
   return result + '\n';
 }

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -36,7 +36,8 @@ function htmlToText(html, options) {
     longWordSplit: {
       wrapCharacters: [],
       forceWrapOnLimit: false
-    }
+    },
+    unorderedListItemPrefix: ' * '
   });
 
   var handler = new htmlparser.DefaultHandler(function (error, dom) {
@@ -53,7 +54,7 @@ function htmlToText(html, options) {
   for (var idx = 0; idx < baseElements.length; ++idx) {
     result += walk(filterBody(handler.dom, options, baseElements[idx]), options);
   }
-  return _s.strip(result);
+  return _s.rtrim(result);
 }
 
 function filterBody(dom, options, baseElement) {

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -231,7 +231,13 @@ describe('html-to-text', function() {
 
       it('should handle an unordered list with multiple elements', function() {
         var testString = '<ul><li>foo</li><li>bar</li></ul>';
-        expect(htmlToText.fromString(testString)).to.equal('* foo\n * bar');
+        expect(htmlToText.fromString(testString)).to.equal(' * foo\n * bar');
+      });
+
+      it('should handle an unordered list prefix option', function() {
+        var testString = '<ul><li>foo</li><li>bar</li></ul>';
+        var options = {unorderedListItemPrefix: ' test '};
+        expect(htmlToText.fromString(testString, options)).to.equal(' test foo\n test bar');
       });
     });
 
@@ -243,46 +249,46 @@ describe('html-to-text', function() {
 
       it('should handle an ordered list with multiple elements', function() {
         var testString = '<ol><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list type="1" attribute', function() {
         var testString = '<ol type="1"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should fallback to type="!" behavior if type attribute is invalid', function() {
         var testString = '<ol type="1"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list type="a" attribute', function() {
         var testString = '<ol type="a"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('a. foo\n b. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' a. foo\n b. bar');
       });
 
       it('should support the ordered list type="A" attribute', function() {
         var testString = '<ol type="A"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('A. foo\n B. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' A. foo\n B. bar');
       });
 
       it('should support the ordered list type="i" attribute by falling back to type="1"', function() {
         var testString = '<ol type="i"><li>foo</li><li>bar</li></ol>';
         // TODO Implement lowercase roman numerals
         // expect(htmlToText.fromString(testString)).to.equal('i. foo\nii. bar');
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list type="I" attribute by falling back to type="1"', function() {
         var testString = '<ol type="I"><li>foo</li><li>bar</li></ol>';
         // TODO Implement uppercase roman numerals
         // expect(htmlToText.fromString(testString)).to.equal('I. foo\nII. bar');
-        expect(htmlToText.fromString(testString)).to.equal('1. foo\n 2. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 
       it('should support the ordered list start attribute', function() {
         var testString = '<ol start="2"><li>foo</li><li>bar</li></ol>';
-        expect(htmlToText.fromString(testString)).to.equal('2. foo\n 3. bar');
+        expect(htmlToText.fromString(testString)).to.equal(' 2. foo\n 3. bar');
       });
 
       /*


### PR DESCRIPTION
Allow for users to specify a different list item prefix other than ` * `