### PR TITLE
html entities in hrefs should not trigger noAnchorUrl

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -179,7 +179,7 @@ rules:
   quotes: 0
   require-jsdoc: 0
   semi-spacing: 0
-  semi: 0
+  semi: [error, always]
   sort-vars: 0
   space-after-keywords: 0
   space-before-blocks: 0

--- a/example/html-to-text.js
+++ b/example/html-to-text.js
@@ -2,7 +2,7 @@ var path = require('path');
 
 var htmlToText = require('../lib/html-to-text');
 
-console.log('fromString:')
+console.log('fromString:');
 var text = htmlToText.fromString('<h1>Hello World</h1>', {
   wordwrap: 130
 });

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -73,10 +73,10 @@ function formatAnchor(elem, fn, options) {
   if (!options.ignoreHref) {
     // Get the href, if present
     if (elem.attribs && elem.attribs.href) {
-      href = elem.attribs.href.replace(/^mailto\:/, '');
+      href = elem.attribs.href.replace(/^mailto:/, '');
     }
     if (href) {
-      if ((!options.noAnchorUrl) || (options.noAnchorUrl && href.indexOf('#') === -1)) {
+      if ((!options.noAnchorUrl) || (options.noAnchorUrl && href[0] !== '#')) {
         if (options.linkHrefBaseUrl && href.indexOf('/') === 0) {
           href = options.linkHrefBaseUrl + href;
         }

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -38,11 +38,11 @@ function formatLineBreak(elem, fn, options) {
 }
 
 function formatParagraph(elem, fn, options) {
-  var paragraph = fn(elem.children, options)
+  var paragraph = fn(elem.children, options);
   if (options.singleNewLineParagraphs) {
-    return paragraph + '\n'
+    return paragraph + '\n';
   } else {
-    return paragraph + '\n\n'
+    return paragraph + '\n\n';
   }
 }
 
@@ -139,12 +139,12 @@ function formatOrderedList(elem, fn, options) {
     // TODO Imeplement the other valid types
     //   Fallback to type '1' function for other valid types
     switch(olType) {
-      case 'a': return function(start, i) { return String.fromCharCode(i + start + 97)};
-      case 'A': return function(start, i) { return String.fromCharCode(i + start + 65)};
+      case 'a': return function(start, i) { return String.fromCharCode(i + start + 97);};
+      case 'A': return function(start, i) { return String.fromCharCode(i + start + 65);};
       case '1':
-      default: return function(start, i) { return i + 1 + start};
+      default: return function(start, i) { return i + 1 + start;};
     }
-  }())
+  }());
   // Make sure there are list items present
   if (nonWhiteSpaceChildren.length) {
     // Calculate initial start from ol attribute

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -69,8 +69,8 @@ function filterBody(dom, options, baseElement) {
         var documentClasses = elem.attribs && elem.attribs.class ? elem.attribs.class.split(" ") : [];
         var documentIds = elem.attribs && elem.attribs.id ? elem.attribs.id.split(" ") : [];
 
-        if ((splitTag.classes.every(function (val) { return documentClasses.indexOf(val) >= 0 })) &&
-          (splitTag.ids.every(function (val) { return documentIds.indexOf(val) >= 0 }))) {
+        if ((splitTag.classes.every(function (val) { return documentClasses.indexOf(val) >= 0; })) &&
+          (splitTag.ids.every(function (val) { return documentIds.indexOf(val) >= 0; }))) {
           result = [elem];
           return;
         }

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -195,6 +195,16 @@ describe('html-to-text', function() {
   });
 
   describe('a', function () {
+    it('should decode html attribute entities from href', function () {
+      var result = htmlToText.fromString('<a href="/foo?a&#x3D;b">test</a>');
+      expect(result).to.equal('test [/foo?a=b]');
+    });
+
+    it('should strip mailto: from email links', function () {
+      var result = htmlToText.fromString('<a href="mailto:foo@example.com">email me</a>');
+      expect(result).to.equal('email me [foo@example.com]');
+    });
+
     it('should return link with brackets', function () {
       var result = htmlToText.fromString('<a href="http://my.link">test</a>');
       expect(result).to.equal('test [http://my.link]');

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -370,7 +370,7 @@ describe('html-to-text', function() {
         }
       });
       expect(result).to.equal('====\ntest\n====');
-    })
+    });
   });
 
   describe('Base element', function () {
@@ -605,5 +605,5 @@ describe('html-to-text', function() {
       testString += "</body></html>";
       expect(htmlToText.fromString(testString)).to.equal(expectedResult);
     });
-  })
+  });
 });


### PR DESCRIPTION
Fixes inadvertent href muting introduced by #123 

I took the liberty of configuring the eslint semi behavior based on the prevailing convention in this code base.