### PR TITLE
Allow recursive custom formatters

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -98,7 +98,7 @@ function formatAnchor(elem, fn, options) {
 
   options.lineCharCount = storedCharCount;
 
-  return formatText({ data: result || href, trimLeadingSpace: elem.trimLeadingSpace }, options);
+  return Object.assign({}, exports, options.format).text({ data: result || href, trimLeadingSpace: elem.trimLeadingSpace }, options);
 }
 
 function formatHorizontalLine(elem, fn, options) {
@@ -128,7 +128,7 @@ function formatUnorderedList(elem, fn, options) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
   });
   nonWhiteSpaceChildren.forEach(function(elem) {
-    result += formatListItem(prefix, elem, fn, options);
+    result += Object.assign({}, exports, options.format).listItem(prefix, elem, fn, options);
   });
   return result + '\n';
 }
@@ -163,7 +163,7 @@ function formatOrderedList(elem, fn, options) {
       // Calculate the needed spacing for nice indentation.
       var spacing = maxLength - index.toString().length;
       var prefix = ' ' + index + '. ' + ' '.repeat(spacing);
-      result += formatListItem(prefix, elem, fn, options);
+      result += Object.assign({}, exports, options.format).listItem(prefix, elem, fn, options);
     });
   }
   return result + '\n';
@@ -220,7 +220,7 @@ function formatTable(elem, fn, options) {
           if (elem.type === 'tag') {
             switch (elem.name.toLowerCase()) {
               case 'th':
-                tokens = formatHeading(elem, fn, options).split('\n');
+                tokens = Object.assign({}, exports, options.format).heading(elem, fn, options).split('\n');
                 rows.push(compact(tokens));
                 break;
 

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -377,6 +377,23 @@ describe('html-to-text', function() {
       });
       expect(result).to.equal('====\ntest\n====');
     });
+
+    it('should use custom formatting functions when nested elements are being parsed', function () {
+      var result = htmlToText.fromString('<ul><li>one</li><li>two</li></ul>', {
+        format: {
+          listItem: function (prefix, elem, fn, options) {
+            options = Object.assign({}, options);
+            if (options.wordwrap) {
+              options.wordwrap -= prefix.length;
+            }
+            var text = fn(elem.children, options);
+            text = text.replace(/\n/g, '\n' + ' '.repeat(prefix.length));
+            return prefix + text.toUpperCase() + '\n';
+          }
+        }
+      });
+      expect(result).to.equal(' * ONE\n * TWO');
+    });
   });
 
   describe('Base element', function () {


### PR DESCRIPTION
* Resolves https://github.com/werk85/node-html-to-text/issues/147
* When format functions are called internally within formatter.js
  it is not possible to override the custom logic. This PR changes that
  functionality and allows users to choose whether they want the
  default formatter to be used internally or their own formatters
  supplied in the options object.