### PR TITLE
Remove additional whitespace after <sup>, fixes #125

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -60,7 +60,7 @@ exports.wordwrap = function wordwrap(text, options) {
   var buffer = [];
   // Split the text into words, decide to preserve new lines or not.
   var words = preserveNewlines
-    ? text.replace(/\n/g, '\n ').split(/\ +/)
+    ? text.trim().replace(/\n/g, '\n ').split(/\ +/)
     : text.trim().split(/\s+/);
 
   // Determine where to end line word by word.

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -595,6 +595,13 @@ describe('html-to-text', function() {
       var testString = 'foo<span> </span>bar';
       expect(htmlToText.fromString(testString)).to.equal('foo bar');
     });
+
+    it('should not add additional whitespace after <sup>', function() {
+      var testString = '<p>This text contains <sup>superscript</sup> text.</p>';
+      var options = { preserveNewlines: true };
+
+      expect(htmlToText.fromString(testString, options)).to.equal('This text contains superscript text.');
+    });
   });
 
   describe('wbr', function() {


### PR DESCRIPTION
Additional whitespace was appearing after `sup`, `strong`, `b` and similar elements if `preserveNewLines`-option was `true`. See #125 for further details.

Testcase included.

Would you care to publish a new version in npm if this and #161 are good to go?