### PR TITLE
Handle lists with line breaks between items

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -125,7 +125,7 @@ function formatUnorderedList(elem, fn, options) {
   var result = '';
   var prefix = options.unorderedListItemPrefix;
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
-    return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
+    return child.name === 'li' && (child.type !== 'text' || !whiteSpaceRegex.test(child.data));
   });
   nonWhiteSpaceChildren.forEach(function(elem) {
     result += formatListItem(prefix, elem, fn, options);
@@ -136,7 +136,7 @@ function formatUnorderedList(elem, fn, options) {
 function formatOrderedList(elem, fn, options) {
   var result = '';
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
-    return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
+    return child.name === 'li' && (child.type !== 'text' || !whiteSpaceRegex.test(child.data));
   });
   // Return different functions for different OL types
   var typeFunction = (function() {

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -244,6 +244,11 @@ describe('html-to-text', function() {
         expect(htmlToText.fromString(testString)).to.equal(' * foo\n * bar');
       });
 
+      it('should handle an unordered list with line break', function() {
+        var testString = '<ul><br><li>foo</li><li>bar</li></ul>';
+        expect(htmlToText.fromString(testString)).to.equal(' * foo\n * bar');
+      });
+
       it('should handle an unordered list prefix option', function() {
         var testString = '<ul><li>foo</li><li>bar</li></ul>';
         var options = {unorderedListItemPrefix: ' test '};
@@ -259,6 +264,11 @@ describe('html-to-text', function() {
 
       it('should handle an ordered list with multiple elements', function() {
         var testString = '<ol><li>foo</li><li>bar</li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
+      });
+
+      it('should handle an ordered list with line break', function() {
+        var testString = '<ol><br><li>foo</li><li>bar</li></ol>';
         expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n 2. bar');
       });
 


### PR DESCRIPTION
Bug:
if ordered list or unordered list contains line breaks `<br>` those will be count as list items `<li>` and they cause extra (empty) numbered (or bulleted) items.

e.g.
`<ol><br><li>foo</li><br><li>bar</li></ol>`
would output
`1.`
`2. foo`
`3.`
`4. bar`

which seems wrong to be.

Fix:
handle only `<li>` children of the ordered and unordered lists.
