### PR TITLE
fix(NestedLists): First element of sublist now indented

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,7 @@
 var max = require('lodash/max');
 var compact = require('lodash/compact');
 var times = require('lodash/times');
+var get = require('lodash/get')
 
 var trimStart = require('lodash/trimStart');
 var padEnd = require('lodash/padEnd');
@@ -122,7 +123,10 @@ function formatListItem(prefix, elem, fn, options) {
 var whiteSpaceRegex = /^\s*$/;
 
 function formatUnorderedList(elem, fn, options) {
-  var result = '';
+  // if this list is a child of a list-item,
+  // ensure that an additional line break is inserted
+  var parentName = get(elem, 'parent.name')
+  var result = parentName === 'li' ? '\n' : '';
   var prefix = options.unorderedListItemPrefix;
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
@@ -134,7 +138,10 @@ function formatUnorderedList(elem, fn, options) {
 }
 
 function formatOrderedList(elem, fn, options) {
-  var result = '';
+  // if this list is a child of a list-item,
+  // ensure that an additional line break is inserted
+  var parentName = get(elem, 'parent.name')
+  var result = parentName === 'li' ? '\n' : '';
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
   });


### PR DESCRIPTION
As per #47, first element of sublist is now indented.
```
<ul>
  <li>1
    <ul>
      <li>2
        <ul>
          <li>3.1</li>
          <li>3.2</li>
        </ul>
      </li>
    </ul>
  </li>
</ul>
```

Correctly outputs as:

```
* 1
  * 2
    * 3.1
    * 3.2
```

Rather than previously outputting as:

```
* 1 * 2 * 3.1
       * 3.2
```