### PR TITLE
fix(NestedLists): First element of sublist now indented + tests

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,7 @@
 var max = require('lodash/max');
 var compact = require('lodash/compact');
 var times = require('lodash/times');
+var get = require('lodash/get');
 
 var trimStart = require('lodash/trimStart');
 var padEnd = require('lodash/padEnd');
@@ -122,7 +123,10 @@ function formatListItem(prefix, elem, fn, options) {
 var whiteSpaceRegex = /^\s*$/;
 
 function formatUnorderedList(elem, fn, options) {
-  var result = '';
+  // if this list is a child of a list-item,
+  // ensure that an additional line break is inserted
+  var parentName = get(elem, 'parent.name');
+  var result = parentName === 'li' ? '\n' : '';
   var prefix = options.unorderedListItemPrefix;
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
@@ -134,7 +138,8 @@ function formatUnorderedList(elem, fn, options) {
 }
 
 function formatOrderedList(elem, fn, options) {
-  var result = '';
+  var nestedList = get(elem, 'parent.name') === 'li';
+  var result = nestedList ? '\n' : '';
   var nonWhiteSpaceChildren = (elem.children || []).filter(function(child) {
     return child.type !== 'text' || !whiteSpaceRegex.test(child.data);
   });
@@ -162,7 +167,7 @@ function formatOrderedList(elem, fn, options) {
       var index = typeFunction(start, i);
       // Calculate the needed spacing for nice indentation.
       var spacing = maxLength - index.toString().length;
-      var prefix = ' ' + index + '. ' + ' '.repeat(spacing);
+      var prefix = nestedList ? '' : ' ' + index + '. ' + ' '.repeat(spacing);
       result += formatListItem(prefix, elem, fn, options);
     });
   }

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -249,6 +249,11 @@ describe('html-to-text', function() {
         var options = {unorderedListItemPrefix: ' test '};
         expect(htmlToText.fromString(testString, options)).to.equal(' test foo\n test bar');
       });
+
+      it('should handle nested ul correctly', function() {
+        var testString = '<ul><li>foo<ul><li>bar<ul><li>baz.1</li><li>baz.2</li></ul></li></ul></li></ul>';
+        expect(htmlToText.fromString(testString)).to.equal(' * foo\n    * bar\n       * baz.1\n       * baz.2');
+      });
     });
 
     describe('ol', function() {
@@ -299,6 +304,11 @@ describe('html-to-text', function() {
       it('should support the ordered list start attribute', function() {
         var testString = '<ol start="2"><li>foo</li><li>bar</li></ol>';
         expect(htmlToText.fromString(testString)).to.equal(' 2. foo\n 3. bar');
+      });
+
+      it('should handle nested ol correctly', function() {
+        var testString = '<ol><li>foo<ol><li>bar<ol><li>baz</li><li>baz</li></ol></li></ol></li></ol>';
+        expect(htmlToText.fromString(testString)).to.equal(' 1. foo\n    1. bar\n       1. baz\n       2. baz');
       });
 
       /*


### PR DESCRIPTION
As per #47, first element of sublist is now indented.
```
<ul>
  <li>1
    <ul>
      <li>2
        <ul>
          <li>3.1</li>
          <li>3.2</li>
        </ul>
      </li>
    </ul>
  </li>
</ul>
```
Correctly outputs as:
```
* 1
  * 2
    * 3.1
    * 3.2
```
Rather than previously outputting as:
```
* 1 * 2 * 3.1
       * 3.2
```
Tests updated and passing