### PR TITLE
added merged tags feature

### DIFF
--- a/example/html-to-text.js
+++ b/example/html-to-text.js
@@ -4,14 +4,24 @@ var htmlToText = require('../lib/html-to-text');
 
 console.log('fromString:');
 var text = htmlToText.fromString('<h1>Hello World</h1>', {
-  wordwrap: 130
+  wordwrap: 130,
+  hasMergedTags: true,
+  mergedTags: {
+    'name': 'Mudassir'
+  }
 });
 console.log(text);
 console.log();
 
 console.log('fromFile:');
 htmlToText.fromFile(path.join(__dirname, 'test.html'), {
-  tables: ['#invoice', '.address']
+  tables: ['#invoice', '.address'],
+  hasMergedTags: true,
+  mergedTags: {
+    'name': 'Mudassir',
+    'email': 'mudassir@test.com',
+    'date': '12 Feb 2019'
+  }
 }, function(err, text) {
   if (err) return console.error(err);
   console.log(text);

--- a/example/test.html
+++ b/example/test.html
@@ -13,6 +13,10 @@
 		</script>
 		<table cellpadding="0" cellspacing="0" border="0">
 			<tr>
+				<td>{{ name}} {{ email }} </td>
+				<td>{{date}}</td>
+			</tr>
+			<tr>
 				<td>
 					<h2>Paragraphs</h2>
 					<p class="normal-space">At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. <a href="www.github.com">Github</a>

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -36,7 +36,9 @@ function htmlToText(html, options) {
       wrapCharacters: [],
       forceWrapOnLimit: false
     },
-    unorderedListItemPrefix: ' * '
+    unorderedListItemPrefix: ' * ',
+    hasMergedTags: false,
+    mergedTags: {}
   }, options || {});
 
   var handler = new htmlparser.DefaultHandler(function (error, dom) {
@@ -186,6 +188,12 @@ function walk(dom, options, result) {
   return result;
 }
 
+function removeSpacesFromMergedTags(str){
+  return str.replace(/\{\{.*?\}\}/g, function(str) {
+      return str.replace(/\s/g, '');
+  })
+}
+
 exports.fromFile = function(file, options, callback) {
   if (!callback) {
     callback = options;
@@ -193,10 +201,32 @@ exports.fromFile = function(file, options, callback) {
   }
   fs.readFile(file, 'utf8', function (err, str) {
     if (err) return callback(err);
+
+    if(options.hasMergedTags && typeof options.mergedTags === 'object'){
+
+      str = removeSpacesFromMergedTags(str);
+      Object.keys(options.mergedTags).forEach((mergedTagKey) => {
+        var rx = new RegExp(`\{\{${mergedTagKey}\}\}`, 'gi');
+        str = str.replace(rx, options.mergedTags[mergedTagKey]);
+      });
+
+    }
+
     return callback(null, htmlToText(str, options));
   });
 };
 
 exports.fromString = function(str, options) {
+
+  if(options.hasMergedTags && typeof options.mergedTags === 'object'){
+
+    str = removeSpacesFromMergedTags(str);
+    Object.keys(options.mergedTags).forEach((mergedTagKey) => {
+      var rx = new RegExp(`\{\{${mergedTagKey}\}\}`, 'gi');
+      str = str.replace(rx, options.mergedTags[mergedTagKey]);
+    });
+    
+  }
+
   return htmlToText(str, options || {});
 };

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -194,6 +194,20 @@ function removeSpacesFromMergedTags(str){
   })
 }
 
+function replaceMergedTagsWithValues(hasMergedTags, mergedTags, str){
+
+  if(hasMergedTags && typeof mergedTags === 'object' && mergedTags !== null){
+
+    str = removeSpacesFromMergedTags(str);
+    Object.keys(mergedTags).forEach((mergedTagKey) => {
+      var rx = new RegExp(`\{\{${mergedTagKey}\}\}`, 'gi');
+      str = str.replace(rx, mergedTags[mergedTagKey]);
+    });
+    
+  }
+  return str;
+}
+
 exports.fromFile = function(file, options, callback) {
   if (!callback) {
     callback = options;
@@ -202,31 +216,15 @@ exports.fromFile = function(file, options, callback) {
   fs.readFile(file, 'utf8', function (err, str) {
     if (err) return callback(err);
 
-    if(options.hasMergedTags && typeof options.mergedTags === 'object'){
-
-      str = removeSpacesFromMergedTags(str);
-      Object.keys(options.mergedTags).forEach((mergedTagKey) => {
-        var rx = new RegExp(`\{\{${mergedTagKey}\}\}`, 'gi');
-        str = str.replace(rx, options.mergedTags[mergedTagKey]);
-      });
-
-    }
-
+    str = replaceMergedTagsWithValues(options.hasMergedTags, options.mergedTags, str);
+    
     return callback(null, htmlToText(str, options));
   });
 };
 
 exports.fromString = function(str, options) {
 
-  if(options.hasMergedTags && typeof options.mergedTags === 'object'){
-
-    str = removeSpacesFromMergedTags(str);
-    Object.keys(options.mergedTags).forEach((mergedTagKey) => {
-      var rx = new RegExp(`\{\{${mergedTagKey}\}\}`, 'gi');
-      str = str.replace(rx, options.mergedTags[mergedTagKey]);
-    });
-    
-  }
+  str = replaceMergedTagsWithValues(options.hasMergedTags, options.mergedTags, str);
 
   return htmlToText(str, options || {});
 };


### PR DESCRIPTION
Hello,
        Very Nice html-to-text module. It worked fine when we want to convert static html to text but I was unable to put/change text in html/template before conversion. I have to change manually in the generated text. I have added merged tags option in it. Just add merge tags in the .html file like {{name}}, {{email}} and set mergedTags in option when the functions htmlToText.fromFile/htmlToText.fromString is called. In this way node code will get merged tags values from variables and will insert automatically. out put text will have values for merged tags.