### PR TITLE
[DOS vulnerability fix] Limit how many DOM nodes get iterated upon

### DIFF
--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -11,7 +11,8 @@ var SKIP_TYPES = [
   'script'
 ];
 
-var MAX_BASE = 10;
+var MAX_BASE = 20;
+var MAX_DOM = 200;
 var MAX_ELEMENTS = 4000;
 
 function htmlToText(html, options) {
@@ -130,6 +131,8 @@ function walk(dom, options, result) {
   if (options.maxElements <= 0) {
     return result;
   }
+
+  dom = dom.slice(0, MAX_DOM);
 
   dom.forEach(function(elem) {
     switch(elem.type) {

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -13,7 +13,7 @@ var SKIP_TYPES = [
 
 var MAX_BASE = 20;
 var MAX_DOM = 200;
-var MAX_ELEMENTS = 4000;
+var MAX_ELEMENTS = 2000;
 
 function htmlToText(html, options) {
   options = Object.assign({

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -11,6 +11,9 @@ var SKIP_TYPES = [
   'script'
 ];
 
+var MAX_BASE = 10;
+var MAX_ELEMENTS = 4000;
+
 function htmlToText(html, options) {
   options = Object.assign({
     wordwrap: 80,
@@ -44,10 +47,12 @@ function htmlToText(html, options) {
   new htmlparser.Parser(handler).parseComplete(html);
 
   options.lineCharCount = 0;
+  options.maxElements = MAX_ELEMENTS;
 
   var result = '';
   var baseElements = Array.isArray(options.baseElement) ? options.baseElement : [options.baseElement];
-  for (var idx = 0; idx < baseElements.length; ++idx) {
+
+  for (var idx = 0; idx < baseElements.length && idx < MAX_BASE; ++idx) {
     result += walk(filterBody(handler.dom, options, baseElements[idx]), options);
   }
   return trimEnd(result);
@@ -58,8 +63,17 @@ function filterBody(dom, options, baseElement) {
 
   var splitTag = helper.splitCssSearchTag(baseElement);
 
+  var maxElements = MAX_ELEMENTS;
+
   function walk(dom) {
     if (result) return;
+
+    maxElements--;
+
+    if (maxElements <= 0) {
+      return result;
+    }
+
     dom.forEach(function(elem) {
       if (result) return;
       if (elem.name === splitTag.element) {
@@ -107,7 +121,13 @@ function walk(dom, options, result) {
   var whiteSpaceRegex = /\s$/;
   var format = Object.assign({}, defaultFormat, options.format);
 
+  options.maxElements--;
+
   if (!dom) {
+    return result;
+  }
+
+  if (options.maxElements <= 0) {
     return result;
   }
 


### PR DESCRIPTION
We're using `node-html-to-text` at scale in production for Crisp (https://crisp.chat/); thanks for the work!

Our inbound email system has been put offline a few days ago due to `node-html-to-text` being vulnerable to attacks where the parsed HTML would be either super-deep, or have a LOT of DOM elements, or both.

We noticed via a NodeJS `--prof` check that the `walk()` method was being called a huge number of times. This can be considered as a DOS vulnerability, and was fixed in our fork with hard-coded limits (that are high).

After deploying the patch in this PR in production, we've not seen any more load / downtime issues.

**Here's how we fixed it:**

1. Limit the number of base DOM elements that can be iterated upon (`MAX_BASE` set to 10);
2. Limit the width of a DOM children iteration (`MAX_DOM` set to 200);
3. Limit the recursive depth of the `walk()` method (`MAX_ELEMENTS` set to 2000);

I'm looking forward to get this PR merged into the NPMJS package 😉 