### PR TITLE
Remove hard-coded CLI options

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,15 +1,27 @@
 #!/usr/bin/env node
-var optimist = require('optimist');
+var parseArgs = require('minimist');
 
 var htmlToText = require('../lib/html-to-text');
 
-var argv = optimist
-  .string('tables')
-  .default('wordwrap', 80)
-  .default('ignore-href', false)
-  .default('ignore-image', false)
-  .default('noLinkBrackets', false)
-  .argv;
+var argv = parseArgs(process.argv.slice(2), {
+  string: [
+    'tables'
+  ],
+  boolean: [
+    'noLinkBrackets',
+    'ignoreHref',
+    'ignoreImage'
+  ],
+  alias: {
+    'ignore-href': 'ignoreHref',
+    'ignore-image': 'ignoreImage'
+  },
+  default: {
+    'wordwrap': 80
+  }
+});
+
+argv.tables = interpretTables(argv.tables);
 
 var text = '';
 
@@ -22,13 +34,7 @@ process.stdin.on('data', function data(data) {
 });
 
 process.stdin.on('end', function end() {
-  text = htmlToText.fromString(text, {
-    tables: interpretTables(argv.tables),
-    wordwrap: argv.wordwrap,
-    ignoreHref: argv['ignore-href'],
-    ignoreImage: argv['ignore-image'],
-    noLinkBrackets: argv['noLinkBrackets']
-  });
+  text = htmlToText.fromString(text, argv);
   process.stdout.write(text + '\n', 'utf-8');
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-text",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1820,9 +1820,10 @@
       }
     },
     "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -2137,9 +2138,18 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -3038,7 +3048,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "he": "^1.2.0",
     "htmlparser2": "^3.10.1",
-    "lodash": "^4.17.11",
-    "optimist": "^0.6.1"
+    "minimist": "^1.2.0",
+    "lodash": "^4.17.11"
   },
   "keywords": [
     "html",


### PR DESCRIPTION
Remove hardcoded CLI options to allow for usage of all settings from documentation.

Replaced 'optimist' library with better supported and smaller library 'minimist'

Added 'ignore-href' and 'ignore-image' aliases to support the previous version's hardcoded option names.

Thanks