### PR TITLE
Support multiline blockquote

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -256,7 +256,9 @@ function formatTable(elem, fn, options) {
 }
 
 function formatBlockquote(elem, fn, options) {
-  return '> ' + fn(elem.children, options) + '\n';
+  // Trim leading/trailing whitespace around blockquotes
+  var text = fn(elem.children, options).trim();
+  return '> ' + text.replace(/(?:\n)/g, '\n> ') + '\n';
 }
 
 exports.text = formatText;

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -589,10 +589,20 @@ describe('html-to-text', function() {
   });
 
   describe('blockquote', function() {
-    it('should handle format blockquote', function() {
+    it('should handle format single-line blockquote', function() {
       var testString = 'foo<blockquote>test</blockquote>bar';
       var expectedResult = 'foo> test\nbar';
       expect(htmlToText.fromString(testString)).to.equal(expectedResult);
     });
+    it('should format multi-line blockquote', function () {
+      var testString = '<blockquote>a<br/>b</blockquote>';
+      var expectedResult = '> a\n> b';
+      expect(htmlToText.fromString(testString)).to.equal(expectedResult);
+    })
+    it('should trim newlines', function () {
+      var testString = '<blockquote><br/>a<br/><br/><br/></blockquote>';
+      var expectedResult = '> a';
+      expect(htmlToText.fromString(testString)).to.equal(expectedResult);
+    })
   });
 });


### PR DESCRIPTION
Sample Text:
```
<blockquote>a<br/>b</blockquote>
```
Current Output:
```
> a
b
```
Expected Output:
```
> a
> b