### PR TITLE
fix eaten unicode whitespaces issue

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -55,7 +55,7 @@ exports.wordwrap = function wordwrap(text, options) {
   var length = options.lineCharCount;
 
   // Preserve leading space
-  var result = text.startsWith(' ') ? ' ' : '';
+  var result = /^[^\S\r\n\t]/.test(text) ? ' ' : ''; //tests for any leading whitespace excluding new lines and tabs
   length += result.length;
   var buffer = [];
   // Split the text into words, decide to preserve new lines or not.
@@ -101,7 +101,7 @@ exports.wordwrap = function wordwrap(text, options) {
   result += buffer.join(' ');
 
   // Preserve trailing space
-  if (!text.endsWith(' ')) {
+  if (!/[^\S\r\n\t]$/.test(text)) { //tests for any trailing whitespace excluding new lines and tabs
     result = trimEnd(result);
   } else if (!result.endsWith(' ')) {
     result = result + ' ';

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -583,6 +583,11 @@ describe('html-to-text', function() {
 
       expect(htmlToText.fromString(testString, options)).to.equal('This text contains superscript text.');
     });
+
+    it('should handle unicode whitespaces the same as the regular one', function() {
+      var testString = '<span>test text' + String.fromCharCode(160) + '</span><div>last line</div>';
+      expect(htmlToText.fromString(testString, {wordwrap: false})).to.equal('test text last line');
+    });
   });
 
   describe('wbr', function() {


### PR DESCRIPTION
It drops leading/trailing Unicode white-spaces (like non-breakable space) if they're not HTML-encoded. 
It is fixed by testing for space by "\s" regexp excluding new line and tab characters.